### PR TITLE
iOS swipe to go back and Android predictive back working

### DIFF
--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentAndroidPredictiveBack.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentAndroidPredictiveBack.kt
@@ -33,7 +33,6 @@ import io.github.hristogochev.vortex.navigator.Navigator
 import io.github.hristogochev.vortex.stack.StackEvent
 import io.github.hristogochev.vortex.transitions.AndroidPredictiveBackTransition
 import io.github.hristogochev.vortex.transitions.AndroidPredictiveBackTransitionCancellable
-import io.github.hristogochev.vortex.transitions.ScreenTransitionCancellable
 import io.github.hristogochev.vortex.util.currentOrThrow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
@@ -46,7 +45,7 @@ import kotlin.coroutines.cancellation.CancellationException
 /**
  *  Displays the current screen of a [Navigator] with an Android predictive back gesture.
  *
- *  The Android predictive back gesture transition is configurable by overriding [PredictiveBackScreenTransition]
+ *  The Android predictive back gesture transition is configurable by overriding [ScreenTransitionCancellable]
  *
  *  Takes in a default [ScreenTransition] for when a screen enters and leaves the visible area.
  *

--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentAndroidPredictiveBack.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentAndroidPredictiveBack.kt
@@ -1,0 +1,227 @@
+package io.github.hristogochev.vortex.screen
+
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.SeekableTransitionState
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import io.github.hristogochev.vortex.model.ScreenModelStore
+import io.github.hristogochev.vortex.navigator.LocalNavigatorStateHolder
+import io.github.hristogochev.vortex.navigator.Navigator
+import io.github.hristogochev.vortex.stack.StackEvent
+import io.github.hristogochev.vortex.transitions.AndroidPredictiveBackTransition
+import io.github.hristogochev.vortex.transitions.AndroidPredictiveBackTransitionCancellable
+import io.github.hristogochev.vortex.transitions.ScreenTransitionCancellable
+import io.github.hristogochev.vortex.util.currentOrThrow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ *  Displays the current screen of a [Navigator] with an Android predictive back gesture.
+ *
+ *  The Android predictive back gesture transition is configurable by overriding [PredictiveBackScreenTransition]
+ *
+ *  Takes in a default [ScreenTransition] for when a screen enters and leaves the visible area.
+ *
+ *  By default the transition is as close as we can get to the native iOS transition.
+ *
+ *  Each [Screen] can have it's own transition for when it enters and leaves the visible area.
+ */
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@Composable
+public fun CurrentScreenAndroidPredictiveBack(
+    navigator: Navigator,
+    defaultOnScreenAppearTransition: ScreenTransition? = LocalDensity.current.let { density -> remember(density) { AndroidPredictiveBackTransition.Appear(density) } },
+    defaultOnScreenDisappearTransition: ScreenTransition? = LocalDensity.current.let { density -> remember(density) { AndroidPredictiveBackTransition.Disappear(density) } },
+    defaultOnPredictiveBackTransition: ScreenTransitionCancellable = LocalDensity.current.let { density -> remember(density) { AndroidPredictiveBackTransitionCancellable(density) } },
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.TopStart,
+    contentKey: (Screen) -> Any = { it.key },
+    disableSwipeToGoBack: Boolean = false,
+    content: @Composable AnimatedVisibilityScope.(Screen) -> Unit = { it.Content() },
+) {
+    // Configure disposal like in CurrentScreen
+    var unexpectedScreenStateKeysQueue by rememberSaveable(saver = unexpectedScreenStateKeysQueueSaver()) {
+        mutableStateOf(emptySet())
+    }
+
+    val oldScreens = navigator.items
+
+    DisposableEffect(oldScreens) {
+        onDispose {
+            val oldScreenStateKeys = oldScreens.map { "${it.key}:${navigator.key}" }
+            val currentScreenStateKeys = navigator.items.map { "${it.key}:${navigator.key}" }
+            val unexpectedScreenStateKeys = oldScreenStateKeys.filter {
+                it !in currentScreenStateKeys
+            }
+            unexpectedScreenStateKeysQueue += unexpectedScreenStateKeys
+        }
+    }
+
+    // Make sure the transition state's target state is always the state of the latest screen
+    val transitionState = remember {
+        SeekableTransitionState(navigator.current)
+    }
+
+    val transition = rememberTransition(transitionState, label = "entry")
+
+    LaunchedEffect(navigator.current) {
+        transitionState.animateTo(navigator.current)
+    }
+
+    val prevScreen by remember(navigator.current) {
+        derivedStateOf {
+            if (navigator.items.size < 2) {
+                return@derivedStateOf null
+            }
+            navigator.items[navigator.items.lastIndex - 1]
+        }
+    }
+
+    var isInPredictiveBack by remember { mutableStateOf(false) }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    PredictiveBackHandler(!disableSwipeToGoBack && prevScreen != null) { progress ->
+        val prevScreen = prevScreen ?: return@PredictiveBackHandler
+
+        progress.onEach { backEvent ->
+            // Fix for swiping back during a normal transition
+            if (!isInPredictiveBack && transitionState.fraction > 0) return@onEach
+            isInPredictiveBack = true
+            transitionState.seekTo(backEvent.progress, prevScreen)
+        }.onCompletion { cause ->
+            if (!isInPredictiveBack) return@onCompletion
+            when (cause) {
+                null -> {
+                    navigator.pop()
+                    isInPredictiveBack = false
+                }
+
+                is CancellationException -> {
+                    coroutineScope.launch {
+                        val mutex = Mutex()
+                        animate(
+                            transitionState.fraction,
+                            0f,
+                            animationSpec = defaultOnPredictiveBackTransition.cancellableAnimationSpec
+                        ) { value, _ ->
+                            launch {
+                                mutex.withLock {
+                                    transitionState.seekTo(value)
+                                    if (value == 0f) {
+                                        isInPredictiveBack = false
+                                        transitionState.snapTo(navigator.current)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    isInPredictiveBack = false
+                }
+            }
+        }.collect()
+    }
+
+    var currentContentTransform by remember { mutableStateOf<ContentTransform?>(null) }
+    transition.AnimatedContent(
+        transitionSpec = {
+            val transition = when {
+                isInPredictiveBack -> defaultOnPredictiveBackTransition
+
+                navigator.lastEvent == StackEvent.Pop -> initialState.onDisappearTransition
+                    ?: defaultOnScreenDisappearTransition
+
+                else -> targetState.onAppearTransition ?: defaultOnScreenAppearTransition
+            }
+
+            ContentTransform(
+                targetContentEnter = transition?.enter() ?: EnterTransition.None,
+                initialContentExit = transition?.exit() ?: ExitTransition.None,
+                targetContentZIndex = transition?.zIndex ?: 0f,
+                sizeTransform = transition?.sizeTransform() ?: SizeTransform()
+            ).also {
+                currentContentTransform = it
+            }
+        },
+        contentAlignment = contentAlignment,
+        contentKey = contentKey,
+        modifier = modifier
+    ) { screen ->
+        if (this.transition.targetState == this.transition.currentState) {
+            val stateHolder = LocalNavigatorStateHolder.currentOrThrow
+
+            // This updates when the transition is done
+            LaunchedEffect(Unit) {
+                currentContentTransform?.targetContentZIndex = 0f
+
+                // We perform a check again, we remove all from the unexpected queue that are actually expected
+                val currentScreenStateKeys = navigator.items.map { "${it.key}:${navigator.key}" }
+
+                val unexpectedScreenStateKeys = unexpectedScreenStateKeysQueue
+                    .filter { it !in currentScreenStateKeys }
+
+                if (unexpectedScreenStateKeys.isNotEmpty()) {
+
+                    for (unexpectedScreenStateKey in unexpectedScreenStateKeys) {
+                        ScreenModelStore.dispose(unexpectedScreenStateKey)
+
+                        ScreenDisposableEffectStore.dispose(unexpectedScreenStateKey)
+
+                        stateHolder.removeState(unexpectedScreenStateKey)
+
+                        navigator.disassociateScreenStateKey(unexpectedScreenStateKey)
+                    }
+
+                    navigator.clearEvent()
+                }
+
+                unexpectedScreenStateKeysQueue = emptySet()
+            }
+        }
+
+        screen.render {
+            content(it)
+        }
+    }
+}
+
+/**
+ * Just an utility saver for the screens that should be disposed during a transition.
+ */
+private fun unexpectedScreenStateKeysQueueSaver(): Saver<MutableState<Set<String>>, List<String>> {
+    return Saver(
+        save = { it.value.toList() },
+        restore = { mutableStateOf(it.toSet()) }
+    )
+}

--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackSpec.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackSpec.kt
@@ -1,0 +1,123 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.PathEasing
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+
+/*
+Urls:
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/anim/activity_open_enter.xml;bpv=1;bpt=0
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/anim/activity_open_exit.xml;bpv=1;bpt=0
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/anim/activity_close_enter.xml;bpv=1;bpt=0
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/anim/activity_close_exit.xml;bpv=1;bpt=0
+
+Or
+
+https://android.googlesource.com/platform/frameworks/base/+/HEAD/core/res/res/anim/activity_open_enter.xml
+https://android.googlesource.com/platform/frameworks/base/+/HEAD/core/res/res/anim/activity_open_exit.xml
+https://android.googlesource.com/platform/frameworks/base/+/HEAD/core/res/res/anim/activity_close_enter.xml
+https://android.googlesource.com/platform/frameworks/base/+/HEAD/core/res/res/anim/activity_close_exit.xml
+
+And then in interpolator folder you can find the interpolators
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/interpolator/fast_out_extra_slow_in.xml;bpv=1;bpt=0
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/interpolator/standard_accelerate.xml;bpv=1;bpt=0
+https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/res/res/interpolator/linear.xml;bpv=1;bpt=0
+ */
+
+/* ----------  E A S I N G  ---------- */
+
+// <pathInterpolator fast_out_extra_slow_in.xml>
+private val FastOutExtraSlowInEasing = PathEasing(
+    PathParser().parsePathString(
+        "M0,0 C0.05,0 0.133333,0.06 0.166666,0.4 " +
+            "C0.208333,0.82 0.25,1 1,1"
+    ).toPath()            // parse → PathNode list → Path
+)                                          // :contentReference[oaicite:0]{index=0}
+
+// <pathInterpolator standard_accelerate.xml>
+private val StandardAccelerateEasing = CubicBezierEasing(0.3f, 0f, 1f, 1f)  // :contentReference[oaicite:1]{index=1}
+
+/* ----------  C O R E   S P E C S  ---------- */
+
+private const val SLIDE_DURATION = 450       // all slide/extend anims are 450 ms
+private const val PREDICTIVE_BACK_SCALE_DURATION = (SLIDE_DURATION * 0.1).toInt()
+private const val FADE_DURATION  =  83       // both fades last   83 ms
+
+private val FadeOutSpec: TweenSpec<Float>
+    get() = tween(
+        durationMillis = FADE_DURATION,
+        delayMillis = 35,                        // activity_close_exit.xml          :contentReference[oaicite:2]{index=2}
+        easing = LinearEasing                    // linear.xml                       :contentReference[oaicite:3]{index=3}
+    )
+
+private val FadeInSpec: TweenSpec<Float>
+    get() = tween(
+        durationMillis = FADE_DURATION,
+        delayMillis = 50,                        // activity_open_enter.xml          :contentReference[oaicite:4]{index=4}
+        easing = LinearEasing                    // linear.xml                       :contentReference[oaicite:5]{index=5}
+    )
+
+private val SlideSpecForward: TweenSpec<IntOffset>
+    get() = tween(
+        durationMillis = SLIDE_DURATION,
+        easing = FastOutExtraSlowInEasing        // open / close slide anims
+    )
+
+private val SlideSpecBackward: TweenSpec<IntOffset>
+    get() = tween(
+        durationMillis = SLIDE_DURATION,
+        easing = StandardAccelerateEasing        // open_exit.xml outgoing page      :contentReference[oaicite:6]{index=6}
+    )
+
+private val SlideSpecForwardPredictiveBack: TweenSpec<IntOffset>
+    get() = tween(
+        durationMillis = SLIDE_DURATION,
+        delayMillis = PREDICTIVE_BACK_SCALE_DURATION,
+        easing = FastOutExtraSlowInEasing        // open / close slide anims
+    )
+
+/* ----------  O F F S E T   H E L P E R  ---------- */
+
+private const val SHIFT = 96                 // the XML uses 96 dp
+private fun shiftPx(density: Density) =
+    with(density) { SHIFT.dp.roundToPx() }                    // density-aware px value
+
+/* ----------  T R A N S I T I O N S  ---------- */
+
+// Forward navigation  ➡️  (activity_open_enter / _exit)
+internal fun androidPredictiveBackEnterForward(density: Density): EnterTransition =
+    slideInHorizontally(
+        initialOffsetX = { shiftPx(density) },      // from +96 dp → 0                 :contentReference[oaicite:7]{index=7}
+        animationSpec = SlideSpecForward
+    ) + fadeIn(animationSpec = FadeInSpec)   // α 0→1
+
+internal fun androidPredictiveBackExitForward(density: Density): ExitTransition =
+    slideOutHorizontally(
+        targetOffsetX = { -shiftPx(density) },      // to –96 dp                       :contentReference[oaicite:8]{index=8}
+        animationSpec = SlideSpecBackward
+    ) + fadeOut(animationSpec = FadeOutSpec)
+
+// Pop-back navigation  ⬅️  (activity_close_enter / _exit)
+internal fun androidPredictiveBackEnterBackward(density: Density): EnterTransition =
+    slideInHorizontally(
+        initialOffsetX = { -shiftPx(density) },     // from –96 dp → 0                :contentReference[oaicite:9]{index=9}
+        animationSpec = SlideSpecForward
+    ) + fadeIn(animationSpec = FadeInSpec)
+
+internal fun androidPredictiveBackExitBackward(density: Density): ExitTransition =
+    slideOutHorizontally(
+        targetOffsetX = { shiftPx(density) },       // to +96 dp                      :contentReference[oaicite:10]{index=10}
+        animationSpec = SlideSpecForward
+    ) + fadeOut(animationSpec = FadeOutSpec) // α 1→0

--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransition.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransition.kt
@@ -1,0 +1,18 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.ui.unit.Density
+import io.github.hristogochev.vortex.screen.ScreenTransition
+
+public sealed class AndroidPredictiveBackTransition : ScreenTransition {
+    public data class Appear(val density: Density) : AndroidPredictiveBackTransition() {
+        override fun enter(): EnterTransition = androidPredictiveBackEnterForward(density)
+        override fun exit(): ExitTransition = androidPredictiveBackExitForward(density)
+    }
+
+    public data class Disappear(val density: Density) : AndroidPredictiveBackTransition() {
+        override fun enter(): EnterTransition = androidPredictiveBackEnterBackward(density)
+        override fun exit(): ExitTransition = androidPredictiveBackExitBackward(density)
+    }
+}

--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransitionCancellable.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransitionCancellable.kt
@@ -6,8 +6,10 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.unit.Density
+import io.github.hristogochev.vortex.screen.ScreenTransitionCancellable
 
-public data class AndroidPredictiveBackTransitionCancellable(val density: Density) : ScreenTransitionCancellable {
+public data class AndroidPredictiveBackTransitionCancellable(val density: Density) :
+    ScreenTransitionCancellable {
     override val zIndex: Float? = -1f
 
     override val cancellableAnimationSpec: AnimationSpec<Float> = tween(

--- a/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransitionCancellable.kt
+++ b/vortex/src/androidMain/kotlin/io/github/hristogochev/vortex/transitions/AndroidPredictiveBackTransitionCancellable.kt
@@ -1,0 +1,21 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.unit.Density
+
+public data class AndroidPredictiveBackTransitionCancellable(val density: Density) : ScreenTransitionCancellable {
+    override val zIndex: Float? = -1f
+
+    override val cancellableAnimationSpec: AnimationSpec<Float> = tween(
+        durationMillis = 100,
+        easing = LinearEasing
+    )
+
+    override fun enter(): EnterTransition = androidPredictiveBackEnterBackward(density)
+
+    override fun exit(): ExitTransition = androidPredictiveBackExitBackward(density)
+}

--- a/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/screen/ScreenTransitionCancellable.kt
+++ b/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/screen/ScreenTransitionCancellable.kt
@@ -1,7 +1,6 @@
-package io.github.hristogochev.vortex.transitions
+package io.github.hristogochev.vortex.screen
 
 import androidx.compose.animation.core.AnimationSpec
-import io.github.hristogochev.vortex.screen.ScreenTransition
 
 public interface ScreenTransitionCancellable : ScreenTransition {
     public val cancellableAnimationSpec: AnimationSpec<Float>

--- a/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/transitions/ScreenTransitionCancellable.kt
+++ b/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/transitions/ScreenTransitionCancellable.kt
@@ -1,0 +1,8 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.core.AnimationSpec
+import io.github.hristogochev.vortex.screen.ScreenTransition
+
+public interface ScreenTransitionCancellable : ScreenTransition {
+    public val cancellableAnimationSpec: AnimationSpec<Float>
+}

--- a/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentIOSSwipe2.kt
+++ b/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentIOSSwipe2.kt
@@ -1,0 +1,228 @@
+package io.github.hristogochev.vortex.screen
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.SeekableTransitionState
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.backhandler.PredictiveBackHandler
+import io.github.hristogochev.vortex.model.ScreenModelStore
+import io.github.hristogochev.vortex.navigator.LocalNavigatorStateHolder
+import io.github.hristogochev.vortex.navigator.Navigator
+import io.github.hristogochev.vortex.stack.StackEvent
+import io.github.hristogochev.vortex.transitions.IOSSlideTransition
+import io.github.hristogochev.vortex.transitions.IOSSlideTransitionCancellable
+import io.github.hristogochev.vortex.transitions.ScreenTransitionCancellable
+import io.github.hristogochev.vortex.util.currentOrThrow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ *  Displays the current screen of a [Navigator] with an iOS-like swipe transition.
+ *
+ *  The iOS-like swipe back transition is configurable by overriding [SwipeBackScreenTransition]
+ *
+ *  Takes in a default [ScreenTransition] for when a screen enters and leaves the visible area.
+ *
+ *  By default the transition is as close as we can get to the native iOS transition.
+ *
+ *  Each [Screen] can have it's own transition for when it enters and leaves the visible area.
+ */
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@Composable
+public fun CurrentScreenIOSSwipe2(
+    navigator: Navigator,
+    defaultOnScreenAppearTransition: ScreenTransition? = IOSSlideTransition.Appear,
+    defaultOnScreenDisappearTransition: ScreenTransition? = IOSSlideTransition.Disappear,
+    defaultOnSwipeBackTransition: ScreenTransitionCancellable = IOSSlideTransitionCancellable,
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.TopStart,
+    contentKey: (Screen) -> Any = { it.key },
+    disableSwipeToGoBack: Boolean = false,
+    content: @Composable AnimatedVisibilityScope.(Screen) -> Unit = { it.Content() },
+) {
+    // Configure disposal like in CurrentScreen
+    var unexpectedScreenStateKeysQueue by rememberSaveable(saver = unexpectedScreenStateKeysQueueSaver()) {
+        mutableStateOf(emptySet())
+    }
+
+    val oldScreens = navigator.items
+
+    DisposableEffect(oldScreens) {
+        onDispose {
+            val oldScreenStateKeys = oldScreens.map { "${it.key}:${navigator.key}" }
+            val currentScreenStateKeys = navigator.items.map { "${it.key}:${navigator.key}" }
+            val unexpectedScreenStateKeys = oldScreenStateKeys.filter {
+                it !in currentScreenStateKeys
+            }
+            unexpectedScreenStateKeysQueue += unexpectedScreenStateKeys
+        }
+    }
+
+    // Make sure the transition state's target state is always the state of the latest screen
+    val transitionState = remember {
+        SeekableTransitionState(navigator.current)
+    }
+
+    val transition = rememberTransition(transitionState, label = "entry")
+
+    LaunchedEffect(navigator.current) {
+        transitionState.animateTo(navigator.current)
+    }
+
+    val prevScreen by remember(navigator.current) {
+        derivedStateOf {
+            if (navigator.items.size < 2) {
+                return@derivedStateOf null
+            }
+            navigator.items[navigator.items.lastIndex - 1]
+        }
+    }
+
+    var isInPredictiveBack by remember { mutableStateOf(false) }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    PredictiveBackHandler(!disableSwipeToGoBack && prevScreen != null) { progress ->
+        val prevScreen = prevScreen ?: return@PredictiveBackHandler
+
+        progress.onEach { backEvent ->
+            // Fix for swiping back during a normal transition
+            if (!isInPredictiveBack && transitionState.fraction > 0) return@onEach
+            // Make sure we can only swipe left to right
+            if (backEvent.swipeEdge == 1) return@onEach
+            isInPredictiveBack = true
+            transitionState.seekTo(backEvent.progress, prevScreen)
+        }.onCompletion { cause ->
+            if (!isInPredictiveBack) return@onCompletion
+            when (cause) {
+                null -> {
+                    navigator.pop()
+                    isInPredictiveBack = false
+                }
+
+                is CancellationException -> {
+                    coroutineScope.launch {
+                        val mutex = Mutex()
+                        animate(
+                            transitionState.fraction,
+                            0f,
+                            animationSpec = defaultOnSwipeBackTransition.cancellableAnimationSpec
+                        ) { value, _ ->
+                            launch {
+                                mutex.withLock {
+                                    transitionState.seekTo(value)
+                                    if (value == 0f) {
+                                        isInPredictiveBack = false
+                                        transitionState.snapTo(navigator.current)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    isInPredictiveBack = false
+                }
+            }
+        }.collect()
+    }
+
+    var currentContentTransform by remember { mutableStateOf<ContentTransform?>(null) }
+    transition.AnimatedContent(
+        transitionSpec = {
+            val transition = when {
+                isInPredictiveBack -> defaultOnSwipeBackTransition
+
+                navigator.lastEvent == StackEvent.Pop -> initialState.onDisappearTransition
+                    ?: defaultOnScreenDisappearTransition
+
+                else -> targetState.onAppearTransition ?: defaultOnScreenAppearTransition
+            }
+
+            ContentTransform(
+                targetContentEnter = transition?.enter() ?: EnterTransition.None,
+                initialContentExit = transition?.exit() ?: ExitTransition.None,
+                targetContentZIndex = transition?.zIndex ?: 0f,
+                sizeTransform = transition?.sizeTransform() ?: SizeTransform()
+            ).also {
+                currentContentTransform = it
+            }
+        },
+        contentAlignment = contentAlignment,
+        contentKey = contentKey,
+        modifier = modifier
+    ) { screen ->
+        if (this.transition.targetState == this.transition.currentState) {
+            val stateHolder = LocalNavigatorStateHolder.currentOrThrow
+
+            // This updates when the transition is done
+            LaunchedEffect(Unit) {
+                currentContentTransform?.targetContentZIndex = 0f
+
+                // We perform a check again, we remove all from the unexpected queue that are actually expected
+                val currentScreenStateKeys = navigator.items.map { "${it.key}:${navigator.key}" }
+
+                val unexpectedScreenStateKeys = unexpectedScreenStateKeysQueue
+                    .filter { it !in currentScreenStateKeys }
+
+                if (unexpectedScreenStateKeys.isNotEmpty()) {
+
+                    for (unexpectedScreenStateKey in unexpectedScreenStateKeys) {
+                        ScreenModelStore.dispose(unexpectedScreenStateKey)
+
+                        ScreenDisposableEffectStore.dispose(unexpectedScreenStateKey)
+
+                        stateHolder.removeState(unexpectedScreenStateKey)
+
+                        navigator.disassociateScreenStateKey(unexpectedScreenStateKey)
+                    }
+
+                    navigator.clearEvent()
+                }
+
+                unexpectedScreenStateKeysQueue = emptySet()
+            }
+        }
+
+        screen.render {
+            content(it)
+        }
+    }
+}
+
+/**
+ * Just an utility saver for the screens that should be disposed during a transition.
+ */
+private fun unexpectedScreenStateKeysQueueSaver(): Saver<MutableState<Set<String>>, List<String>> {
+    return Saver(
+        save = { it.value.toList() },
+        restore = { mutableStateOf(it.toSet()) }
+    )
+}

--- a/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentIOSSwipe2.kt
+++ b/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentIOSSwipe2.kt
@@ -32,7 +32,6 @@ import io.github.hristogochev.vortex.navigator.Navigator
 import io.github.hristogochev.vortex.stack.StackEvent
 import io.github.hristogochev.vortex.transitions.IOSSlideTransition
 import io.github.hristogochev.vortex.transitions.IOSSlideTransitionCancellable
-import io.github.hristogochev.vortex.transitions.ScreenTransitionCancellable
 import io.github.hristogochev.vortex.util.currentOrThrow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
@@ -45,7 +44,7 @@ import kotlin.coroutines.cancellation.CancellationException
 /**
  *  Displays the current screen of a [Navigator] with an iOS-like swipe transition.
  *
- *  The iOS-like swipe back transition is configurable by overriding [SwipeBackScreenTransition]
+ *  The iOS-like swipe back transition is configurable by overriding [ScreenTransitionCancellable]
  *
  *  Takes in a default [ScreenTransition] for when a screen enters and leaves the visible area.
  *

--- a/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransition.kt
+++ b/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransition.kt
@@ -1,0 +1,29 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import io.github.hristogochev.vortex.screen.ScreenTransition
+
+public sealed class IOSSlideTransition : ScreenTransition {
+    public data object Appear : IOSSlideTransition() {
+        override fun enter(): EnterTransition =
+            slideInHorizontally(spring(stiffness = Spring.StiffnessLow)) { it }
+
+        override fun exit(): ExitTransition =
+            slideOutHorizontally(spring(stiffness = Spring.StiffnessLow)) { -(it.toFloat() * 0.3f).toInt() }
+    }
+
+    public data object Disappear : IOSSlideTransition() {
+        override val zIndex: Float? = -1f
+
+        override fun enter(): EnterTransition =
+            slideInHorizontally(spring(stiffness = Spring.StiffnessLow)) { -(it.toFloat() * 0.3f).toInt() }
+
+        override fun exit(): ExitTransition =
+            slideOutHorizontally(spring(stiffness = Spring.StiffnessLow)) { it }
+    }
+}

--- a/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransitionCancellable.kt
+++ b/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransitionCancellable.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import io.github.hristogochev.vortex.screen.ScreenTransitionCancellable
 
 public data object IOSSlideTransitionCancellable : ScreenTransitionCancellable {
     override val zIndex: Float? = -1f

--- a/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransitionCancellable.kt
+++ b/vortex/src/nativeMain/kotlin/io/github/hristogochev/vortex/transitions/IOSSlideTransitionCancellable.kt
@@ -1,0 +1,34 @@
+package io.github.hristogochev.vortex.transitions
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+
+public data object IOSSlideTransitionCancellable : ScreenTransitionCancellable {
+    override val zIndex: Float? = -1f
+
+    override val cancellableAnimationSpec: AnimationSpec<Float> = tween(
+        durationMillis = 100,
+        easing = LinearEasing
+    )
+
+    override fun enter(): EnterTransition =
+        slideInHorizontally(
+            animationSpec = tween(
+                durationMillis = 100,
+                easing = LinearEasing
+            )
+        ) { -(it.toFloat() * 0.3f).toInt() }
+
+    override fun exit(): ExitTransition =
+        slideOutHorizontally(
+            animationSpec = tween(
+                durationMillis = 100,
+                easing = LinearEasing
+            )
+        ) { it }
+}


### PR DESCRIPTION
@hristogochev The pull request is not done yet, but here you can see how it is supposed to work.  

Android is working as well. The default Android transition is the real default Android transition right now in the system, but translated to use compose. However, I did not find the transition for the predictive back gesture. I have it somewhat in my own app, but that needs the predictive back gesture to submit a maximum fraction to the animation and some other things which I'm not sure how to implement. Also it's somewhat the same as on my phone, but not exactly.  
Let me know if you want the default Android transition as it is right now, I can remove it if you don't want it. 

iOS is now called `CurrentScreenIOSSwipe2` until we are fully done here. Swipe to go back is working with your fixes. However, the z-index is indeed wrong after two swipes back, so I added my fix again. 

To make this all work, I needed to place the specific parts in iosMain and androidMain, because PredictiveBackHandler was not available in commonMain.  Also I commented TabNavigation because it gave me some errors. And also included a targetSdk, otherwise Android would go into support mode. 

As you can see the two are quite similar for now. Not sure if we will need some changes to better support one or the other. But for now it could be merged together. I think iOS is really nice already. But for Android I have some doubts, because I'm not sure what would be nice for the predictive back gesture. If I look on my phone, it scales to about 80-90% when fully swiped. After release it scales back up and finishes the normal transition. If it's not fully swiped, it just finishes the transition from there (not sure how to do this one). Also when moving my finger up and down, it translates a little bit up and down (also not sure how to do this). 

Also in my opinion, we should also add it to the specific Screen as an override. But I'm not sure yet how we should provide that. We could add an extra interface which you can implement to override the predictive or swipe to go back. But we need to support both inside commonMain. If we can merge the Android part and iOS part this would be easier. Or we could provide a common part which has a different implementation on Android as to iOS. 

For issue #9 