### PR TITLE
Fix iOS predictive back snapping back after a few dp (stable onBack handler)

### DIFF
--- a/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentPredictiveBack.kt
+++ b/vortex/src/commonMain/kotlin/io/github/hristogochev/vortex/screen/ScreenCurrentPredictiveBack.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -91,7 +92,10 @@ public fun CurrentScreenPredictiveBack(
         transitionState.animateTo(navigator.current)
     }
 
-    val prevScreen by remember(navigator.current) {
+    // Un-keyed derived state: it reads snapshot state (navigator.items), so it
+    // stays current without being recreated per navigation - the remembered
+    // onBack below can safely capture the State instance itself.
+    val prevScreenState = remember {
         derivedStateOf {
             if (navigator.items.size < 2) {
                 return@derivedStateOf null
@@ -99,8 +103,9 @@ public fun CurrentScreenPredictiveBack(
             navigator.items[navigator.items.lastIndex - 1]
         }
     }
+    val prevScreen by prevScreenState
 
-    val currentScreenCanPop by remember(navigator.current) {
+    val currentScreenCanPop by remember {
         derivedStateOf {
             navigator.current.canPop
         }
@@ -110,53 +115,68 @@ public fun CurrentScreenPredictiveBack(
 
     val coroutineScope = rememberCoroutineScope()
 
+    val updatedPredictiveBackTransition = rememberUpdatedState(defaultPredictiveBackTransition)
+    val updatedSwipeSides = rememberUpdatedState(swipeSides)
+
+    // The onBack lambda must be ONE stable instance for the lifetime of this
+    // composition: Compose's PredictiveBackHandler keys the platform handler on
+    // the lambda instance, so a fresh instance created by a mid-gesture
+    // recomposition (the first seekTo triggers one) tears the handler down and
+    // cancels the in-flight gesture - on iOS the screen tracked the finger for a
+    // few dp and then snapped back. Live values are read through State instances
+    // captured by the lambda instead of raw captures. The lambda's type is never
+    // written out because BackEventCompat is not part of the stable public API on
+    // all targets - rememberOnBack lets it flow in by inference.
     PredictiveBackHandler(
         enabled = enabled && prevScreen != null && currentScreenCanPop,
-        onBack = onBack@{ progress ->
-            val prevScreen = prevScreen ?: return@onBack
+        onBack = rememberOnBack(
+            navigator, transitionState, coroutineScope,
+            onBack = onBack@{ progress ->
+                val prevScreen = prevScreenState.value ?: return@onBack
 
-            progress
-                .filter { backEvent ->
-                    swipeSides.contains(backEvent.swipeEdge)
-                }.onEach { backEvent ->
-                    if (!isInPredictiveBack && transitionState.fraction > 0) return@onEach
-                    isInPredictiveBack = true
-                    transitionState.seekTo(backEvent.progress, prevScreen)
-                }.onCompletion { cause ->
-                    if (!isInPredictiveBack) return@onCompletion
-                    when (cause) {
-                        null -> {
-                            navigator.pop()
-                            isInPredictiveBack = false
-                        }
+                progress
+                    .filter { backEvent ->
+                        updatedSwipeSides.value.contains(backEvent.swipeEdge)
+                    }.onEach { backEvent ->
+                        if (!isInPredictiveBack && transitionState.fraction > 0) return@onEach
+                        isInPredictiveBack = true
+                        transitionState.seekTo(backEvent.progress, prevScreen)
+                    }.onCompletion { cause ->
+                        if (!isInPredictiveBack) return@onCompletion
+                        when (cause) {
+                            null -> {
+                                navigator.pop()
+                                isInPredictiveBack = false
+                            }
 
-                        is CancellationException -> {
-                            coroutineScope.launch {
-                                val mutex = Mutex()
-                                animate(
-                                    transitionState.fraction,
-                                    0f,
-                                    animationSpec = defaultPredictiveBackTransition.cancelAnimationSpec
-                                ) { value, _ ->
-                                    launch {
-                                        mutex.withLock {
-                                            transitionState.seekTo(value)
-                                            if (value == 0f) {
-                                                isInPredictiveBack = false
-                                                transitionState.snapTo(navigator.current)
+                            is CancellationException -> {
+                                coroutineScope.launch {
+                                    val mutex = Mutex()
+                                    animate(
+                                        transitionState.fraction,
+                                        0f,
+                                        animationSpec = updatedPredictiveBackTransition.value.cancelAnimationSpec
+                                    ) { value, _ ->
+                                        launch {
+                                            mutex.withLock {
+                                                transitionState.seekTo(value)
+                                                if (value == 0f) {
+                                                    isInPredictiveBack = false
+                                                    transitionState.snapTo(navigator.current)
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
-                        }
 
-                        else -> {
-                            isInPredictiveBack = false
+                            else -> {
+                                isInPredictiveBack = false
+                            }
                         }
-                    }
-                }.collect()
-        })
+                    }.collect()
+            })
+    )
 
     var currentContentTransform by remember { mutableStateOf<ContentTransform?>(null) }
     transition.AnimatedContent(
@@ -221,6 +241,15 @@ public fun CurrentScreenPredictiveBack(
         }
     }
 }
+
+/**
+ * remember() that keeps the FIRST [onBack] for the given keys, so the handler
+ * registration survives recompositions. Generic so the caller never has to name
+ * the lambda's parameter type - it flows in by inference.
+ */
+@Composable
+private fun <T : Any> rememberOnBack(vararg keys: Any?, onBack: T): T =
+    remember(*keys) { onBack }
 
 /**
  * Just an utility saver for the screens that should be disposed during a transition.


### PR DESCRIPTION
### The bug

On Compose Multiplatform 1.12, every back swipe in `CurrentScreenPredictiveBack`
tracks the finger for a few dp and then snaps back, on every screen. The gesture
effectively cancels itself.

### Root cause

`CurrentScreenPredictiveBack` passes `PredictiveBackHandler` an inline `onBack`
lambda. Its captures include `swipeSides: List<Int>` (an unstable type), which
defeats the Compose compiler's lambda memoization - so a **new lambda instance is
created on every recomposition**.

Compose's `PredictiveBackHandler` keys the platform handler registration on the
lambda instance (in CMP 1.12 the two-arg overload is a bridge that does
`remember(compositeKey, onBack)`). The chain during a drag is:

1. First back event arrives, `transitionState.seekTo(...)` runs.
2. The seek changes state and triggers a recomposition.
3. Recomposition creates a fresh `onBack` instance.
4. The changed `remember` key disposes the registered handler and registers a
   new one.
5. On iOS, disposing the handler cancels the in-flight
   `UIScreenEdgePanGestureRecognizer` - the screen snaps back.

### The fix

Remember **one** `onBack` for the lifetime of the composition, so the handler
registration survives recomposition for the whole gesture:

- `onBack` is wrapped in a small `rememberOnBack` helper (a generic
  `remember(*keys) { value }`). It is generic so the lambda's parameter type is
  never written out - `BackEventCompat` is not nameable on all targets in
  CMP 1.12 - and the type flows in by inference from the call site.
- Values that can change across recompositions are read through State instead of
  raw captures: `defaultPredictiveBackTransition` and `swipeSides` via
  `rememberUpdatedState`, `prevScreen` via the captured `derivedStateOf`
  instance.
- The `prevScreen` / `currentScreenCanPop` derived states are no longer keyed on
  `navigator.current`. They read snapshot state (`navigator.items`,
  `navigator.current`) so they stay current on their own, and un-keying them
  lets the remembered lambda capture a stable State instance.

No public API changes.

### Testing

Compiled for commonMain metadata, iosArm64 and Android release. Verified in a
production Compose Multiplatform 1.12 app on a physical iPhone: before the
change every edge swipe snapped back after ~25dp; with the remembered handler
the predictive back gesture tracks, cancels and completes correctly across all
screens.
